### PR TITLE
Add tests for parser

### DIFF
--- a/src/main/java/seedu/address/logic/parser/LocalCourseAddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/LocalCourseAddCommandParser.java
@@ -3,6 +3,7 @@ package seedu.address.logic.parser;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PARAMETER_LOCALCODE;
 import static seedu.address.logic.parser.CliSyntax.PARAMETER_LOCALNAME;
+import static seedu.address.logic.parser.ParserUtil.areValuesEnclosedAndNonEmpty;
 
 import java.util.stream.Stream;
 
@@ -45,39 +46,6 @@ public class LocalCourseAddCommandParser implements Parser<LocalCourseAddCommand
         LocalCourse localCourse = new LocalCourse(localCode, localName);
 
         return new LocalCourseAddCommand(localCourse);
-    }
-
-
-    /**
-     * Returns true if all arguments are enclosed in square brackets, and are non-empty.
-     *
-     * @param args Arguments in the format of {@code [args1] [args2] ...}.
-     * @return true if in correct format.
-     */
-    private static boolean areValuesEnclosedAndNonEmpty(String args) {
-        // The number of unclosed open square brackets, used to validate input.
-        int bracketCount = 0;
-        StringBuilder currValue = new StringBuilder();
-
-        for (int i = 0; i < args.length(); i++) {
-            Character currChar = args.charAt(i);
-            if (currChar.equals('[')) {
-                currValue.setLength(0);
-                bracketCount++;
-            } else if (currChar.equals(']') && currValue.toString().trim().isEmpty()) {
-                return false;
-            } else if (currChar.equals(']')) {
-                bracketCount--;
-            } else {
-                currValue.append(currChar);
-            }
-
-            if (bracketCount < 0 || bracketCount > 1) {
-                return false;
-            }
-        }
-
-        return bracketCount == 0;
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/NoteAddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/NoteAddCommandParser.java
@@ -3,6 +3,7 @@ package seedu.address.logic.parser;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PARAMETER_CONTENT;
 import static seedu.address.logic.parser.CliSyntax.PARAMETER_TAGS;
+import static seedu.address.logic.parser.ParserUtil.areValuesEnclosedAndNonEmpty;
 
 import java.util.stream.Stream;
 
@@ -43,39 +44,6 @@ public class NoteAddCommandParser implements Parser<NoteAddCommand> {
         Note note = new Note(content, tags);
 
         return new NoteAddCommand(note);
-    }
-
-
-    /**
-     * Returns true if all arguments are enclosed in square brackets, and are non-empty.
-     *
-     * @param args Arguments in the format of {@code [args1] [args2] ...}.
-     * @return true if in correct format.
-     */
-    private static boolean areValuesEnclosedAndNonEmpty(String args) {
-        // The number of unclosed open square brackets, used to validate input.
-        int bracketCount = 0;
-        StringBuilder currValue = new StringBuilder();
-
-        for (int i = 0; i < args.length(); i++) {
-            Character currChar = args.charAt(i);
-            if (currChar.equals('[')) {
-                currValue.setLength(0);
-                bracketCount++;
-            } else if (currChar.equals(']') && currValue.toString().trim().isEmpty()) {
-                return false;
-            } else if (currChar.equals(']')) {
-                bracketCount--;
-            } else {
-                currValue.append(currChar);
-            }
-
-            if (bracketCount < 0 || bracketCount > 1) {
-                return false;
-            }
-        }
-
-        return bracketCount == 0;
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -174,4 +174,42 @@ public class ParserUtil {
         String trimmedTags = tags.trim();
         return trimmedTags;
     }
+
+    // SEPlendid ParserUtil starts here
+
+    /**
+     * Returns true if all arguments are enclosed in square brackets, and are non-empty.
+     * The input string must be non-empty.
+     *
+     * @param args Arguments in the format of {@code [args1] [args2] ...}.
+     * @return true if in correct format.
+     */
+    public static boolean areValuesEnclosedAndNonEmpty(String args) {
+        if (args.isEmpty()) {
+            return false;
+        }
+        // The number of unclosed open square brackets, used to validate input.
+        int bracketCount = 0;
+        StringBuilder currValue = new StringBuilder();
+
+        for (int i = 0; i < args.length(); i++) {
+            Character currChar = args.charAt(i);
+            if (currChar.equals('[')) {
+                currValue.setLength(0);
+                bracketCount++;
+            } else if (currChar.equals(']') && currValue.toString().trim().isEmpty()) {
+                return false;
+            } else if (currChar.equals(']')) {
+                bracketCount--;
+            } else {
+                currValue.append(currChar);
+            }
+
+            if (bracketCount < 0 || bracketCount > 1) {
+                return false;
+            }
+        }
+
+        return bracketCount == 0;
+    }
 }

--- a/src/main/java/seedu/address/logic/parser/SeplendidArgumentTokenizer.java
+++ b/src/main/java/seedu/address/logic/parser/SeplendidArgumentTokenizer.java
@@ -83,10 +83,11 @@ public class SeplendidArgumentTokenizer {
             SeplendidParameter param = parameterPosition.getParameter();
             if (startPosition == -1) {
                 parameterToArgMap.put(param, "");
+            } else {
+                int closingSquareBracketPosition = argsString.indexOf("]", startPosition);
+                String argumentValue = argsString.substring(startPosition + 1, closingSquareBracketPosition);
+                parameterToArgMap.put(param, argumentValue);
             }
-            int closingSquareBracketPosition = argsString.indexOf("]", startPosition);
-            String argumentValue = argsString.substring(startPosition + 1, closingSquareBracketPosition);
-            parameterToArgMap.put(param, argumentValue);
         });
         return parameterToArgMap;
     }

--- a/src/main/java/seedu/address/logic/parser/SeplendidParser.java
+++ b/src/main/java/seedu/address/logic/parser/SeplendidParser.java
@@ -8,11 +8,18 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import seedu.address.commons.core.SeplendidLogsCenter;
-import seedu.address.logic.commands.*;
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.HelpCommand;
+import seedu.address.logic.commands.LocalCourseAddCommand;
+import seedu.address.logic.commands.LocalCourseCommand;
+import seedu.address.logic.commands.NoteAddCommand;
+import seedu.address.logic.commands.NoteCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
  * Parses user input into the SEPlendid CLI.
+ * <p>
+ * TBD: Add parsing for help command
  */
 public class SeplendidParser {
 
@@ -37,9 +44,9 @@ public class SeplendidParser {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
         }
 
-        final String commandWord = matcher.group("commandWord");
-        final String actionWord = matcher.group("actionWord");
-        final String arguments = matcher.group("arguments");
+        final String commandWord = matcher.group("commandWord").trim();
+        final String actionWord = matcher.group("actionWord").trim();
+        final String arguments = matcher.group("arguments").trim();
 
         // Note to developers: Change the log level in config.json to enable lower level (i.e., FINE, FINER and lower)
         // log messages such as the one below.
@@ -74,11 +81,11 @@ public class SeplendidParser {
     private NoteAddCommand getNoteCommand(String userInput, String actionWord, String arguments)
             throws ParseException {
         switch (actionWord) {
-            case NoteAddCommand.ACTION_WORD:
-                return new NoteAddCommandParser().parse(arguments);
-            default:
-                logger.finer("This user input caused a ParseException: " + userInput);
-                throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
+        case NoteAddCommand.ACTION_WORD:
+            return new NoteAddCommandParser().parse(arguments);
+        default:
+            logger.finer("This user input caused a ParseException: " + userInput);
+            throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
         }
     }
 

--- a/src/main/java/seedu/address/model/localcourse/LocalCode.java
+++ b/src/main/java/seedu/address/model/localcourse/LocalCode.java
@@ -14,10 +14,11 @@ public class LocalCode {
             + "10 alphanumeric characters";
 
     /*
-     * This matches a string that starts with a non-whitespace character.
+     * This matches alphanumeric string of length 1-10, starting with an alphabet.
      */
     public static final String VALIDATION_REGEX = "[a-zA-Z][a-zA-Z0-9]{0,9}";
 
+    // TBD: refactor codebase to allow this to be set to private
     public final String value;
 
     /**
@@ -35,6 +36,12 @@ public class LocalCode {
         return test.matches(VALIDATION_REGEX);
     }
 
+    public String getValue() {
+        return this.value;
+    }
+
+    // Note: be careful not to modify this, as it is used in auto-invocation of toString
+    // in places where string is expected
     @Override
     public String toString() {
         return value;

--- a/src/main/java/seedu/address/model/localcourse/LocalName.java
+++ b/src/main/java/seedu/address/model/localcourse/LocalName.java
@@ -10,7 +10,8 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class LocalName {
 
     // Used in AppUtil#checkArgument and ParserUtil, JsonAdaptedXXX exceptions
-    public static final String MESSAGE_CONSTRAINTS = "LocalName can take any values, and it should not be blank";
+    public static final String MESSAGE_CONSTRAINTS = "LocalName can take any values, given it starts with a "
+            + "whitespace, and it should not be blank";
 
     /*
      * This matches a string that starts with a non-whitespace character.
@@ -21,10 +22,12 @@ public class LocalName {
 
     /**
      * Constructs an {@code LocalName}.
+     * localName is trimmed before checkArgument, as a standardisation.
      *
      * @param localName A valid localname.
      */
     public LocalName(String localName) {
+        localName = localName.trim();
         requireNonNull(localName);
         checkArgument(isValidLocalName(localName), MESSAGE_CONSTRAINTS);
         value = localName;
@@ -32,6 +35,10 @@ public class LocalName {
 
     public static boolean isValidLocalName(String test) {
         return test.matches(VALIDATION_REGEX);
+    }
+
+    public String getValue() {
+        return this.value;
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -73,16 +73,6 @@ public class CommandTestUtil {
     }
 
     /**
-     * Wraps {@code arg} in square brackets for argument form.
-     *
-     * @param arg This is the argument to be wrapped.
-     * @return The wrapped version of {@code arg}.
-     */
-    public static String getSquareBracketWrappedArgument(String arg) {
-        return String.format("[%s]", arg);
-    }
-
-    /**
      * Executes the given {@code command}, confirms that <br>
      * - the returned {@link CommandResult} matches {@code expectedCommandResult} <br>
      * - the {@code actualModel} matches {@code expectedModel}

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -60,6 +60,9 @@ public class CommandTestUtil {
     public static final EditCommand.EditPersonDescriptor DESC_AMY;
     public static final EditCommand.EditPersonDescriptor DESC_BOB;
 
+    // SEPlendid
+    public static final String UNNCESSARY_WHITESPACE = "  \t  ";
+
     static {
         DESC_AMY = new EditPersonDescriptorBuilder().withName(VALID_NAME_AMY)
                 .withPhone(VALID_PHONE_AMY).withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY)
@@ -70,12 +73,22 @@ public class CommandTestUtil {
     }
 
     /**
+     * Wraps {@code arg} in square brackets for argument form.
+     *
+     * @param arg This is the argument to be wrapped.
+     * @return The wrapped version of {@code arg}.
+     */
+    public static String getSquareBracketWrappedArgument(String arg) {
+        return String.format("[%s]", arg);
+    }
+
+    /**
      * Executes the given {@code command}, confirms that <br>
      * - the returned {@link CommandResult} matches {@code expectedCommandResult} <br>
      * - the {@code actualModel} matches {@code expectedModel}
      */
     public static void assertCommandSuccess(Command command, Model actualModel, CommandResult expectedCommandResult,
-            Model expectedModel) {
+                                            Model expectedModel) {
         try {
             CommandResult result = command.execute(actualModel);
             assertEquals(expectedCommandResult, result);
@@ -90,7 +103,7 @@ public class CommandTestUtil {
      * that takes a string {@code expectedMessage}.
      */
     public static void assertCommandSuccess(Command command, Model actualModel, String expectedMessage,
-            Model expectedModel) {
+                                            Model expectedModel) {
         CommandResult expectedCommandResult = new CommandResult(expectedMessage);
         assertCommandSuccess(command, actualModel, expectedCommandResult, expectedModel);
     }
@@ -111,6 +124,7 @@ public class CommandTestUtil {
         assertEquals(expectedAddressBook, actualModel.getAddressBook());
         assertEquals(expectedFilteredList, actualModel.getFilteredPersonList());
     }
+
     /**
      * Updates {@code model}'s filtered list to show only the person at the given {@code targetIndex} in the
      * {@code model}'s address book.

--- a/src/test/java/seedu/address/logic/parser/LocalCourseAddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/LocalCourseAddCommandParserTest.java
@@ -1,0 +1,115 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.CommandTestUtil.UNNCESSARY_WHITESPACE;
+import static seedu.address.logic.commands.CommandTestUtil.getSquareBracketWrappedArgument;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalObjects.EDGE_CASE_VALID_LOCAL_COURSE;
+import static seedu.address.testutil.TypicalObjects.EDGE_CASE_VALID_LOCAL_COURSE_CODE;
+import static seedu.address.testutil.TypicalObjects.EDGE_CASE_VALID_LOCAL_COURSE_NAME;
+import static seedu.address.testutil.TypicalObjects.INVALID_LOCAL_COURSE_CODE;
+import static seedu.address.testutil.TypicalObjects.INVALID_LOCAL_COURSE_NAME;
+import static seedu.address.testutil.TypicalObjects.TYPICAL_LOCAL_COURSE_CODE;
+import static seedu.address.testutil.TypicalObjects.TYPICAL_LOCAL_COURSE_NAME;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.LocalCourseAddCommand;
+import seedu.address.logic.commands.LocalCourseCommand;
+import seedu.address.model.localcourse.LocalCode;
+import seedu.address.model.localcourse.LocalCourse;
+import seedu.address.testutil.LocalCourseBuilder;
+import seedu.address.testutil.LocalCourseUtil;
+import seedu.address.testutil.TypicalObjects;
+
+public class LocalCourseAddCommandParserTest {
+
+    private static final String commandActionWord = LocalCourseCommand.COMMAND_WORD
+            + " " + LocalCourseAddCommand.ACTION_WORD + " ";
+
+    private LocalCourseAddCommandParser parser = new LocalCourseAddCommandParser();
+
+    @Test
+    public void parse_unnecessaryWhiteSpace_success() {
+        LocalCourse expectedLocalCourse = new LocalCourseBuilder(TypicalObjects.CS2040S).build();
+
+        // add unnecessary whitespace
+        assertParseSuccess(parser, UNNCESSARY_WHITESPACE
+                        + LocalCourseCommand.COMMAND_WORD
+                        + UNNCESSARY_WHITESPACE
+                        + LocalCourseAddCommand.ACTION_WORD
+                        + UNNCESSARY_WHITESPACE
+                        + getSquareBracketWrappedArgument(expectedLocalCourse.getLocalCode().getValue())
+                        + UNNCESSARY_WHITESPACE
+                        + getSquareBracketWrappedArgument(expectedLocalCourse.getLocalName().getValue())
+                        + UNNCESSARY_WHITESPACE,
+                new LocalCourseAddCommand(expectedLocalCourse));
+    }
+
+    @Test
+    void parse_argumentNotClosedOrEmpty_failure() {
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                LocalCourseAddCommand.LOCAL_COURSE_ADD_MESSAGE_USAGE);
+
+        // missing open bracket
+        assertParseFailure(parser, commandActionWord
+                + LocalCourseUtil.getLocalCourseArgumentsForCommand(TypicalObjects.CS3230).substring(
+                1), expectedMessage);
+
+        // empty argument
+        assertParseFailure(parser, commandActionWord
+                + getSquareBracketWrappedArgument(TYPICAL_LOCAL_COURSE_CODE)
+                + " "
+                + getSquareBracketWrappedArgument(""), expectedMessage);
+    }
+
+
+    @Test
+    public void parse_allArgumentMissing_failure() {
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                LocalCourseAddCommand.LOCAL_COURSE_ADD_MESSAGE_USAGE);
+
+        // missing localcode argument
+        assertParseFailure(parser, commandActionWord
+                        + getSquareBracketWrappedArgument(TYPICAL_LOCAL_COURSE_NAME),
+                expectedMessage);
+
+        // missing localname prefix
+        assertParseFailure(parser, commandActionWord
+                        + getSquareBracketWrappedArgument(TYPICAL_LOCAL_COURSE_CODE),
+                expectedMessage);
+
+        // all arguments missing
+        assertParseFailure(parser, commandActionWord, expectedMessage);
+    }
+
+    @Test
+    public void parse_invalidValue_failure() {
+        // invalid localCode
+        assertParseFailure(parser, commandActionWord
+                        + getSquareBracketWrappedArgument(INVALID_LOCAL_COURSE_CODE)
+                        + " " + getSquareBracketWrappedArgument(TYPICAL_LOCAL_COURSE_NAME),
+                LocalCode.MESSAGE_CONSTRAINTS);
+
+        // invalid localName
+        // This test also ensures that the input to checkArgument and parseLocalName matches.
+        // localName is trimmed before checkArgument, as a standardisation
+        // Therefore a localName argument starting with a whitespace will pass,
+        // while a whitespace alone will not. A whitespace alone will trigger
+        // ParseException due to ParserUtil#areValuesEncloseAndNonEmpty.
+        assertParseFailure(parser, commandActionWord
+                        + getSquareBracketWrappedArgument(TYPICAL_LOCAL_COURSE_CODE)
+                        + " " + getSquareBracketWrappedArgument(INVALID_LOCAL_COURSE_NAME),
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                        LocalCourseAddCommand.LOCAL_COURSE_ADD_MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_edgeCaseLocalNameValue_success() {
+        assertParseSuccess(parser, commandActionWord
+                        + getSquareBracketWrappedArgument(EDGE_CASE_VALID_LOCAL_COURSE_CODE)
+                        + " " + getSquareBracketWrappedArgument(EDGE_CASE_VALID_LOCAL_COURSE_NAME),
+                new LocalCourseAddCommand(EDGE_CASE_VALID_LOCAL_COURSE));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/LocalCourseAddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/LocalCourseAddCommandParserTest.java
@@ -2,9 +2,9 @@ package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.CommandTestUtil.UNNCESSARY_WHITESPACE;
-import static seedu.address.logic.commands.CommandTestUtil.getSquareBracketWrappedArgument;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TestUtil.getSquareBracketWrappedArgument;
 import static seedu.address.testutil.TypicalObjects.EDGE_CASE_VALID_LOCAL_COURSE;
 import static seedu.address.testutil.TypicalObjects.EDGE_CASE_VALID_LOCAL_COURSE_CODE;
 import static seedu.address.testutil.TypicalObjects.EDGE_CASE_VALID_LOCAL_COURSE_NAME;

--- a/src/test/java/seedu/address/logic/parser/SeplendidArgumentTokenizerTest.java
+++ b/src/test/java/seedu/address/logic/parser/SeplendidArgumentTokenizerTest.java
@@ -1,0 +1,36 @@
+package seedu.address.logic.parser;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.logic.parser.CliSyntax.PARAMETER_LOCALCODE;
+import static seedu.address.logic.parser.CliSyntax.PARAMETER_LOCALNAME;
+import static seedu.address.testutil.TypicalObjects.TYPICAL_LOCAL_COURSE_CODE;
+import static seedu.address.testutil.TypicalObjects.TYPICAL_LOCAL_COURSE_NAME;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.testutil.TestUtil;
+
+public class SeplendidArgumentTokenizerTest {
+
+    /**
+     * Unit testing of SeplendidArgumentTokenizer
+     */
+    @Test
+    public void tokenize_multipleArguments_success() {
+
+        SeplendidArgumentMap actualArgumentMap = SeplendidArgumentTokenizer.tokenize(
+                TestUtil.getSquareBracketWrappedArgument(TYPICAL_LOCAL_COURSE_CODE)
+                        + TestUtil.getSquareBracketWrappedArgument(TYPICAL_LOCAL_COURSE_NAME),
+                PARAMETER_LOCALCODE, PARAMETER_LOCALNAME);
+
+        assertArgumentEquals(actualArgumentMap, PARAMETER_LOCALCODE, TYPICAL_LOCAL_COURSE_CODE);
+        assertArgumentEquals(actualArgumentMap, PARAMETER_LOCALNAME, TYPICAL_LOCAL_COURSE_NAME);
+
+    }
+
+
+    private void assertArgumentEquals(SeplendidArgumentMap argMultimap, SeplendidParameter parameter,
+                                      String expectedValue) {
+        assertEquals(expectedValue, argMultimap.getValue(parameter).get());
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/SeplendidParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SeplendidParserTest.java
@@ -1,0 +1,61 @@
+package seedu.address.logic.parser;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.HelpCommand;
+import seedu.address.logic.commands.LocalCourseAddCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.localcourse.LocalCourse;
+import seedu.address.testutil.LocalCourseBuilder;
+import seedu.address.testutil.LocalCourseUtil;
+
+public class SeplendidParserTest {
+
+    private final SeplendidParser parser = new SeplendidParser();
+
+    /**
+     * Unit testing with stub-like seed data.
+     */
+    @Test
+    public void parseCommand_addLocalCourse() throws Exception {
+        LocalCourse localCourse = new LocalCourseBuilder().build();
+        // This narrow typecast is safe as LocalCourseAddCommand is a known subtype of Command
+        LocalCourseAddCommand command = (LocalCourseAddCommand) parser
+                .parseCommand(LocalCourseUtil.getLocalCourseAddCommandFrom(localCourse));
+        assertEquals(new LocalCourseAddCommand(localCourse), command);
+    }
+
+
+    //    @Test
+    //    public void parseCommand_help() throws Exception {
+    //        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD) instanceof HelpCommand);
+    //        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD + " 3") instanceof HelpCommand);
+    //    }
+
+    //    @Test
+    //    public void parseCommand_list() throws Exception {
+    //        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD) instanceof ListCommand);
+    //        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3") instanceof ListCommand);
+    //    }
+
+    /**
+     * Testing SeplendidParser class alone
+     */
+    @Test
+    public void parseCommand_unrecognisedInput_throwsParseException() {
+        assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE), ()
+                -> parser.parseCommand(""));
+    }
+
+    @Test
+    public void parseCommand_unknownLocalCourseCommand_throwsParseException() {
+        assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND, ()
+                -> parser.parseCommand("localcourse eject args"));
+    }
+
+}

--- a/src/test/java/seedu/address/testutil/LocalCourseBuilder.java
+++ b/src/test/java/seedu/address/testutil/LocalCourseBuilder.java
@@ -1,0 +1,54 @@
+package seedu.address.testutil;
+
+import seedu.address.model.localcourse.LocalCode;
+import seedu.address.model.localcourse.LocalCourse;
+import seedu.address.model.localcourse.LocalName;
+
+/**
+ * A utility class to help with building LocalCourse objects.
+ */
+public class LocalCourseBuilder {
+
+    public static final String DEFAULT_LOCAL_CODE = "CS2103T";
+    public static final String DEFAULT_LOCAL_NAME = "Software Engineering";
+
+    private LocalCode localCode;
+    private LocalName localName;
+
+    /**
+     * Creates a {@code LocalCourseBuilder} with the default details.
+     */
+    public LocalCourseBuilder() {
+        localCode = new LocalCode(DEFAULT_LOCAL_CODE);
+        localName = new LocalName(DEFAULT_LOCAL_NAME);
+    }
+
+    /**
+     * Initializes the LocalCourseBuilder with the data of {@code localCourseToCopy}.
+     */
+    public LocalCourseBuilder(LocalCourse localCourseToCopy) {
+        localCode = localCourseToCopy.getLocalCode();
+        localName = localCourseToCopy.getLocalName();
+    }
+
+    /**
+     * Sets the {@code LocalCode} of the {@code LocalCourse} that we are building.
+     */
+    public LocalCourseBuilder withLocalCode(String localCode) {
+        this.localCode = new LocalCode(localCode);
+        return this;
+    }
+
+    /**
+     * Sets the {@code LocalName} of the {@code LocalCourse} that we are building.
+     */
+    public LocalCourseBuilder withLocalName(String localName) {
+        this.localName = new LocalName(localName);
+        return this;
+    }
+
+    public LocalCourse build() {
+        return new LocalCourse(localCode, localName);
+    }
+
+}

--- a/src/test/java/seedu/address/testutil/LocalCourseUtil.java
+++ b/src/test/java/seedu/address/testutil/LocalCourseUtil.java
@@ -1,0 +1,53 @@
+package seedu.address.testutil;
+
+import seedu.address.logic.commands.LocalCourseAddCommand;
+import seedu.address.model.localcourse.LocalCourse;
+
+/**
+ * A utility class for LocalCourse.
+ */
+public class LocalCourseUtil {
+
+    /**
+     * Returns an add command string for adding the {@code LocalCourse}.
+     */
+    public static String getLocalCourseAddCommandFrom(LocalCourse localCourse) {
+        return LocalCourseAddCommand.COMMAND_WORD
+                + " "
+                + LocalCourseAddCommand.ACTION_WORD
+                + " "
+                + getLocalCourseArgumentsForCommand(localCourse);
+    }
+
+    /**
+     * Returns the part of command string for the given {@code localCourse}'s details.
+     */
+    public static String getLocalCourseArgumentsForCommand(LocalCourse localCourse) {
+        StringBuilder sb = new StringBuilder("[");
+        sb.append(localCourse.getLocalCode()).append("] [");
+        sb.append(localCourse.getLocalName()).append("]");
+        return sb.toString();
+    }
+
+    // TBD: modify for the purpose of seplendid
+    //    /**
+    //     * Returns the part of command string for the given {@code EditPersonDescriptor}'s details.
+    //     */
+    //    public static String getEditPersonDescriptorDetails(EditPersonDescriptor descriptor) {
+    //        StringBuilder sb = new StringBuilder();
+    //        descriptor.getName().ifPresent(name -> sb.append(PREFIX_NAME).append(name.fullName).append(" "));
+    //        descriptor.getPhone().ifPresent(phone -> sb.append(PREFIX_PHONE).append(phone.value).append(" "));
+    //        descriptor.getEmail().ifPresent(email -> sb.append(PREFIX_EMAIL).append(email.value).append(" "));
+    //        descriptor.getAddress().ifPresent(address -> sb.append(PREFIX_ADDRESS).append(address.value).append(" "));
+    //        if (descriptor.getTags().isPresent()) {
+    //            Set<Tag> tags = descriptor.getTags().get();
+    //            if (tags.isEmpty()) {
+    //                sb.append(PREFIX_TAG);
+    //            } else {
+    //                tags.forEach(s -> sb.append(PREFIX_TAG).append(s.tagName).append(" "));
+    //            }
+    //        }
+    //        return sb.toString();
+    //    }
+
+}

--- a/src/test/java/seedu/address/testutil/TestUtil.java
+++ b/src/test/java/seedu/address/testutil/TestUtil.java
@@ -52,4 +52,14 @@ public class TestUtil {
     public static Person getPerson(Model model, Index index) {
         return model.getFilteredPersonList().get(index.getZeroBased());
     }
+
+    /**
+     * Wraps {@code arg} in square brackets for argument form.
+     *
+     * @param arg This is the argument to be wrapped.
+     * @return The wrapped version of {@code arg}.
+     */
+    public static String getSquareBracketWrappedArgument(String arg) {
+        return String.format("[%s]", arg);
+    }
 }

--- a/src/test/java/seedu/address/testutil/TypicalObjects.java
+++ b/src/test/java/seedu/address/testutil/TypicalObjects.java
@@ -1,0 +1,48 @@
+package seedu.address.testutil;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import seedu.address.model.LocalCourseCatalogue;
+import seedu.address.model.localcourse.LocalCourse;
+
+/**
+ * A utility class containing a list of SEPlendid objects to use in tests.
+ */
+public class TypicalObjects {
+
+    public static final String TYPICAL_LOCAL_COURSE_CODE = "CS2103";
+    public static final String TYPICAL_LOCAL_COURSE_NAME = "Software Engineering";
+
+    public static final String EDGE_CASE_VALID_LOCAL_COURSE_CODE = "S";
+    public static final String EDGE_CASE_VALID_LOCAL_COURSE_NAME = " Software Testing";
+    public static final String INVALID_LOCAL_COURSE_CODE = "$HOW2BECOMERICH";
+    public static final String INVALID_LOCAL_COURSE_NAME = " ";
+
+    public static final LocalCourse CS2040S = new LocalCourseBuilder().withLocalCode("CS2040S")
+            .withLocalName("Data Structures & Algorithms").build();
+    public static final LocalCourse CS3230 = new LocalCourseBuilder().withLocalCode("CS3230")
+            .withLocalName("Design & Analysis of Algorithms").build();
+    public static final LocalCourse EDGE_CASE_VALID_LOCAL_COURSE = new LocalCourseBuilder()
+            .withLocalCode(EDGE_CASE_VALID_LOCAL_COURSE_CODE).withLocalName(EDGE_CASE_VALID_LOCAL_COURSE_NAME).build();
+
+
+    private TypicalObjects() {
+    } // prevents instantiation
+
+    /**
+     * Returns an {@code LocalCourseCatalogue} with all the typical localCourses.
+     */
+    public static LocalCourseCatalogue getTypicalLocalCourseCatalogue() {
+        LocalCourseCatalogue localCourseCatalogue = new LocalCourseCatalogue();
+        for (LocalCourse localCourse : getTypicalLocalCourses()) {
+            localCourseCatalogue.addLocalCourse(localCourse);
+        }
+        return localCourseCatalogue;
+    }
+
+    public static List<LocalCourse> getTypicalLocalCourses() {
+        return new ArrayList<>(Arrays.asList(CS2040S, CS3230));
+    }
+}


### PR DESCRIPTION
# Summary of changes made 
- Add `TypicalObjects`
- Add `LocalCourseUtil`, `LocalCourseBuilder`
- Add `SeplendidParserTest`, `LocalCourseAddCommandParserTest`
- Some parsing bug fixes 
- `SeplendidArgumentTokenizerTest`

# Details to note
- For attributes such as `LocalName`, it follows a `[^\\s].*` regex. Note that we will trim whitespace during initialisation. As such it is difficult to make an argument for e.g. `localname` invalid. One way is to include `[` / `]`. This will trigger the arg is empty check, which does not involve regex.

# To be done after merge
- Improve JUnit testcases for tokenizer, and the such.